### PR TITLE
Add ability to use dynamic refs outside of special functions

### DIFF
--- a/test/axel_f/error_test.cljc
+++ b/test/axel_f/error_test.cljc
@@ -1,5 +1,6 @@
 (ns axel-f.error-test
   (:require [axel-f.error :as sut]
+            [axel-f.core :as af-sut]
             #?(:clj [clojure.test :as t]
                :cljs [cljs.test :as t :include-macros true])))
 
@@ -22,4 +23,17 @@
     (t/is (= {:reason {:foo "1"}
               :type "FOO"} (#?(:clj ex-data
                             :cljs .-data)
-                         (sut/error "FOO" {:foo "1"}))))))
+                            (sut/error "FOO" {:foo "1"})))))
+
+  (t/testing "errors returned bu the formula passed from run function"
+
+    (t/is (= {:type "#VALUE!"}
+             (#?(:clj ex-data
+                 :cljs .-data)
+              (af-sut/run "#VALUE!")))))
+
+  #?(:clj
+     (t/testing "non-excel errors are thrown from run function"
+
+       (t/is (thrown? java.lang.ArithmeticException
+                      (af-sut/run "1 / 0"))))))

--- a/test/axel_f/reference_test.cljc
+++ b/test/axel_f/reference_test.cljc
@@ -87,4 +87,10 @@
     (t/is (= 1 (sut/run "OBJREF({1,2,3}, 0)")))
 
     (t/is (= [{:bar 1} {:bar 2} {:bar 3}]
-             (sut/run "FILTER(foo, _.bar < 4)" {:foo [{:bar 1} {:bar 4} {:bar 2} {:bar 3}]})))))
+             (sut/run "FILTER(foo, _.bar < 4)" {:foo [{:bar 1} {:bar 4} {:bar 2} {:bar 3}]}))))
+
+  (t/testing "dynamic references evaluates into full context object"
+
+    (t/is (= 2 (sut/run "1 + _" 1)))
+
+    (t/is (= {:foo 1 :bar 2} (sut/run "IF(foo = 1, _, #VALUE!)" {:foo 1 :bar 2})))))


### PR DESCRIPTION
Examples:

* `(run "IF(foo > 1, _, #ERROR!) {:foo 2 :bar 2})` will return context object
* `(run "1 + _" 4) ;; => 5`