### PR TITLE
Symbols can be prefixed with escaping character

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:deps {org.clojure/clojure {:mvn/version "1.9.0"}
         clj-fuzzy {:mvn/version "0.4.1"}
-        cheshire {:mvn/version "5.8.1"}}
+        cheshire {:mvn/version "5.8.1"}
+        digest {:mvn/version "1.4.8"}}
 
  :paths ["src"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.xapix</groupId>
     <artifactId>axel-f</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
     <name>axel-f</name>
     <dependencies>
         <dependency>

--- a/release-js/package.json
+++ b/release-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "axel-f",
-    "version": "1.0.2",
+    "version": "1.0.3-SNAPSHOT",
     "description": "axel-f is an engine that can evaluate excel-like expressions.",
     "homepage": "https://github.com/xapix-io/axel-f",
     "author": "Kirill Chernyshov (https://github.com/DeLaGuardo)",

--- a/src/axel_f/functions/hash.cljc
+++ b/src/axel_f/functions/hash.cljc
@@ -1,0 +1,36 @@
+(ns axel-f.functions.hash
+  (:require [axel-f.functions.core :refer [def-excel-fn]]
+            #?@(:clj [[digest :refer [sha-256]]]
+                :cljs [[goog.crypt :as crypt]
+                       [goog.crypt.Sha256 :as Sha256]])))
+
+#?(:cljs
+   (defn string->bytes [s]
+     (crypt/stringToUtf8ByteArray s)))
+
+#?(:cljs
+   (defn bytes->hex
+     "convert bytes to hex"
+     [bytes-in]
+     (crypt/byteArrayToHex bytes-in)))
+
+#?(:cljs
+   (defn digest [hasher bytes]
+     (.update hasher bytes)
+     (.digest hasher)))
+
+#?(:cljs
+   (defn hash-bytes [s]
+     (digest
+      (goog.crypt.Sha256.)
+      (string->bytes s))))
+
+(defn sha256 [msg]
+  #?(:clj (sha-256 msg)
+     :cljs (bytes->hex (hash-bytes msg))))
+
+(def-excel-fn
+  "HASH.SHA256"
+  sha256
+  {:args [{:desc "String to calculate digest"}]
+   :desc "Calculates a sha-256 based digest from a String"})

--- a/src/axel_f/lexer.cljc
+++ b/src/axel_f/lexer.cljc
@@ -27,8 +27,9 @@
   (or (= type ::number)
       (contains? (set "0123456789") t)))
 
-(defn symbol-literal? [{::keys [type]}]
-  (= type ::symbol))
+(defn symbol-literal? [{::keys [type] :as t}]
+  (or (= type ::symbol)
+      (contains? #{\#} t)))
 
 (defn punctuation-literal?
   ([t] (punctuation-literal? t ["," "."]))
@@ -236,6 +237,11 @@
     (loop [acc [] escaped? false end (get-position rdr)]
       (let [ch (reader/peek-elem rdr)]
         (cond
+          (= \# ch)
+          (let [_ (reader/read-elem rdr)
+                s ((get-method read-token! ::text) rdr)]
+            (assoc s ::type ::symbol ::begin begin))
+
           (and escaped? (end-of-input? ch))
           (throw (ex-info "Unexpected end of token"
                           {:position {:begin end

--- a/src/axel_f/parser.cljc
+++ b/src/axel_f/parser.cljc
@@ -4,12 +4,12 @@
             [clojure.string :as string]))
 
 (defn triml-whitespaces [tokens]
-  (if (lexer/whitespace? (first tokens))
+  (if ((some-fn lexer/whitespace? lexer/newline?) (first tokens))
     (recur (rest tokens))
     tokens))
 
 (defn trimr-whitespaces [tokens]
-  (if (lexer/whitespace? (last tokens))
+  (if ((some-fn lexer/whitespace? lexer/newline?) (last tokens))
     (recur (butlast tokens))
     tokens))
 
@@ -217,6 +217,11 @@
       (lexer/postfix-operator? (first tokens'))
       [(runtime/unary-expr (runtime/operator-expr (first tokens')) expr)
        (rest tokens')]
+
+      (or (lexer/punctuation-literal? (first tokens') ["."])
+          (lexer/bracket-literal? (first tokens') ["["]))
+      (parse-expression (cons (runtime/root-reference-expr expr)
+                              tokens'))
 
       :otherwise
       [expr tokens'])))

--- a/src/axel_f/runtime.cljc
+++ b/src/axel_f/runtime.cljc
@@ -113,10 +113,12 @@
    :end (:end (position field-expr))})
 
 (defmethod eval ::root-reference-expr [{::keys [field-expr]} & [g l]]
-  (let [f (eval field-expr g l)]
-    (if (= "_" f)
-      (if (= ::no-ctx l) g l)
-      ((core/find-impl "flexy-get") g f))))
+  (if (= ::application-expr (::type field-expr))
+    (eval field-expr g l)
+    (let [f (eval field-expr g l)]
+      (if (= "_" f)
+        (if (= ::no-ctx l) g l)
+        ((core/find-impl "flexy-get") g f)))))
 
 (defmethod position ::reference-expr [{::keys [ctx-expr field-expr]}]
   (merge (position ctx-expr)

--- a/test/axel_f/hash_test.cljc
+++ b/test/axel_f/hash_test.cljc
@@ -1,0 +1,15 @@
+(ns axel-f.hash-test
+  (:require [axel-f.core :as af]
+            [axel-f.functions.hash :as sut]
+            #?(:clj [clojure.test :as t]
+               :cljs [cljs.test :as t :include-macros true])))
+
+(t/deftest sha256
+  (t/testing "Digest string"
+
+    (t/is (= "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+             (sut/sha256 "foo")))))
+
+(t/deftest HASHSHA256
+  (let [f (af/compile "HASH.SHA256('foo')")]
+    (t/is (= "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae" (f)))))

--- a/test/axel_f/lexer_test.cljc
+++ b/test/axel_f/lexer_test.cljc
@@ -327,6 +327,17 @@
 
 (t/deftest symbols-reading
 
+  (t/is (= [#::sut{:value "foo bar",
+                   :type ::sut/symbol,
+                   :begin #::sut{:line 1, :column 1},
+                   :end #::sut{:line 1, :column 8},
+                   :depth 0}
+            #::sut{:type ::sut/eoi,
+                   :begin #::sut{:line 1, :column 9},
+                   :end #::sut{:line 1, :column 9},
+                   :depth 0}]
+           (sut/read-formula "foo\\ bar")))
+
   (t/is (= [#::sut{:value "foo",
                    :type ::sut/symbol,
                    :begin #::sut{:line 1, :column 1},
@@ -368,7 +379,45 @@
                    :depth 0,
                    :begin #::sut{:line 1, :column 8}
                    :end #::sut{:line 1, :column 8}}]
-           (sut/read-formula "foo/bar"))))
+           (sut/read-formula "foo/bar")))
+
+  (t/is (= [#::sut{:value "foo bar",
+                   :type ::sut/symbol,
+                   :begin #::sut{:line 1, :column 1},
+                   :end #::sut{:line 1, :column 10},
+                   :depth 0}
+            #::sut{:type ::sut/eoi,
+                   :begin #::sut{:line 1, :column 11},
+                   :end #::sut{:line 1, :column 11},
+                   :depth 0}]
+           (sut/read-formula "#'foo bar'")))
+
+  (t/is (= [#::sut{:value "foo bar",
+                   :type ::sut/symbol,
+                   :begin #::sut{:line 1, :column 1},
+                   :end #::sut{:line 1, :column 10},
+                   :depth 0}
+            #::sut{:type ::sut/eoi,
+                   :begin #::sut{:line 1, :column 11},
+                   :end #::sut{:line 1, :column 11},
+                   :depth 0}]
+           (sut/read-formula "#\"foo bar\"")))
+
+  (t/is (= [#::sut{:type ::sut/whitespace,
+                   :value "  ",
+                   :begin #::sut{:line 1, :column 1},
+                   :end #::sut{:line 1, :column 3},
+                   :depth 0}
+            #::sut{:value "foo bar",
+                   :type ::sut/symbol,
+                   :begin #::sut{:line 1, :column 3},
+                   :end #::sut{:line 1, :column 12},
+                   :depth 0}
+            #::sut{:type ::sut/eoi,
+                   :begin #::sut{:line 1, :column 13},
+                   :end #::sut{:line 1, :column 13},
+                   :depth 0}]
+           (sut/read-formula "  #'foo bar'"))))
 
 (t/deftest expression-reading
 

--- a/test/axel_f/parser_test.cljc
+++ b/test/axel_f/parser_test.cljc
@@ -109,6 +109,14 @@
 
 (t/deftest parse-references
 
+  (t/testing "result of function application can be used as a context for reference expression"
+
+    (t/is (= 1
+             (parse* "FILTER(_.x = 1, foo)[0].x" {:foo [{:x 2} {:x 1}]})))
+
+    (t/is (= [1 2 3]
+             (parse* "SORT(_.x, _).[*].x" [{:x 2} {:x 1 :y "af"} {:x 3}]))))
+
   (t/testing "symbols resolved as references during parsing"
 
     (t/is (= 1
@@ -288,3 +296,17 @@
                   #::l{:begin #::l{:line 1, :column 7},
                        :end #::l{:line 1, :column 7}}}
                  data))))))
+
+(t/deftest newlines
+
+  (t/testing "ignore newlines"
+
+    (t/is (= "foobarbaz"
+             (parse* "CONCATENATE('foo',
+                                  'bar',
+                                  'baz')")))
+
+    (t/is (= "foobarbaz"
+             (parse* "'foo' &
+                      'bar' &
+                      'baz'")))))


### PR DESCRIPTION
```
"#'foo bar'" -> {::type ::symbol ::value 'foo bar'}
```

fix #51 