### PR TITLE
Coerce round return type to a long instead of an int

### DIFF
--- a/src/axel_f/functions/math.cljc
+++ b/src/axel_f/functions/math.cljc
@@ -10,7 +10,7 @@
           res (/ (Math/round (* d factor)) factor)]
       (if (> precision 0)
         res
-        (int res)))))
+        (long res)))))
 
 (def round-meta
   {:desc "Rounds a number to a certain number of decimal places according to standard rules."


### PR DESCRIPTION
fixes #74