### PR TITLE
Coerce round return type to a long instead of an int

### DIFF
--- a/src/axel_f/excel/math.cljc
+++ b/src/axel_f/excel/math.cljc
@@ -19,7 +19,7 @@
           res (/ (Math/round (* value factor)) factor)]
       (if (> places 0)
         res
-        (int res)))))
+        (long res)))))
 
 (def ROUND #'ROUND*)
 


### PR DESCRIPTION
fixes #74