### PR TITLE
Correct coercion behavior

### DIFF
--- a/src/axel_f/compiler.cljc
+++ b/src/axel_f/compiler.cljc
@@ -153,8 +153,8 @@
   (let [entries (mapv (partial compile env) entries)]
     (with-meta
       (fn [ctx]
-        (for [x entries]
-          (x ctx)))
+        (vec (for [x entries]
+               (x ctx))))
       (merge {:free-variables (mapcat #(:free-variables (meta %)) entries)}
              (select-keys l [::lexer/begin ::lexer/end])))))
 

--- a/src/axel_f/excel/coerce.cljc
+++ b/src/axel_f/excel/coerce.cljc
@@ -58,8 +58,11 @@
   "Tries to coerce given value to float type. Returns null for empty value or values not reducible to float."
   [^{:doc "Any object to coerce to a float."} obj]
   (try
-    (if (float? obj)
+    (cond
+      (number? obj)
       (double obj)
+
+      (string? obj)
       #?(:clj (Double/parseDouble obj)
          :cljs (let [n (when (not-empty obj)
                          (js/Number obj))]

--- a/test/axel_f/complex_validation_test.cljc
+++ b/test/axel_f/complex_validation_test.cljc
@@ -50,6 +50,7 @@
   (t/is (= 3.14 ((af/compile "coerce.to-float(3.14)"))))
   (t/is (= true ((af/compile "coerce.to-boolean('true')"))))
   (t/is (= nil
+           ((af/compile "coerce.to-float(OBJECT.NEW({{'foo', 1}}))"))
            ((af/compile "coerce.to-integer('qwe')"))
            ((af/compile "coerce.to-float('qwe')"))
            ((af/compile "coerce.to-boolean('qwe')")))))


### PR DESCRIPTION
* lists realization lazy-seq -> vector
* coerce.to-float should work with any numeric types and string

fix xapix-io/xapix#237
fix xapix-io/xapix#238