### PR TITLE
Add PARSE.DATE and PARSE.DATETIME functions

### DIFF
--- a/src/axel_f/excel/date.cljc
+++ b/src/axel_f/excel/date.cljc
@@ -46,11 +46,13 @@
                         :local-date-time jt/local-date-time)
                       pattern date-string))
                    :cljs
-                   (.strictParse (goog.i18n.DateTimeParse. pattern)
-                                 date-string
-                                 (case type
-                                   :local-date-time (local-date-time)
-                                   :local-date (local-date)))))])
+                   (let [date (case type
+                                :local-date-time (local-date-time)
+                                :local-date (local-date))]
+                     (.strictParse (goog.i18n.DateTimeParse. pattern)
+                                   date-string
+                                   date)
+                     (epoch-milli date))))])
 
 (defmethod coerce/inst "LocalDate" [[_ millis]]
   #?(:clj (.. (java.time.Instant/ofEpochMilli millis) (atZone (java.time.ZoneId/systemDefault)) toLocalDate)

--- a/src/axel_f/excel/date.cljc
+++ b/src/axel_f/excel/date.cljc
@@ -46,9 +46,7 @@
                         :local-date-time jt/local-date-time)
                       pattern date-string))
                    :cljs
-                   (let [date (case type
-                                :local-date (local-date)
-                                :local-date-time (local-date-time))]
+                   (let [date (js/Date. (js/Date.UTC 0 0 0 0 0 0 0))]
                      (.strictParse (goog.i18n.DateTimeParse. pattern)
                                    date-string
                                    date)

--- a/src/axel_f/excel/date.cljc
+++ b/src/axel_f/excel/date.cljc
@@ -52,7 +52,7 @@
                      (.strictParse (goog.i18n.DateTimeParse. pattern)
                                    date-string
                                    date)
-                     (epoch-milli date))))])
+                     date)))])
 
 (defmethod coerce/inst "LocalDate" [[_ millis]]
   #?(:clj (.. (java.time.Instant/ofEpochMilli millis) (atZone (java.time.ZoneId/systemDefault)) toLocalDate)

--- a/src/axel_f/excel/date.cljc
+++ b/src/axel_f/excel/date.cljc
@@ -84,7 +84,9 @@
 (defn TODAY*
   "Returns the current date as a date value."
   []
-  ["LocalDate" (epoch-milli (local-date))])
+  ["LocalDate"
+   #?(:clj (.toEpochMilli (.toInstant (.atStartOfDay (jt/local-date) (ZoneId/ofOffset "UTC" (ZoneOffset/ofHours 0)))))
+      :cljs (epoch-milli (local-date)))])
 
 (def TODAY #'TODAY*)
 

--- a/src/axel_f/excel/date.cljc
+++ b/src/axel_f/excel/date.cljc
@@ -47,8 +47,8 @@
                       pattern date-string))
                    :cljs
                    (let [date (case type
-                                :local-date-time (local-date-time)
-                                :local-date (local-date))]
+                                :local-date (local-date)
+                                :local-date-time (local-date-time))]
                      (.strictParse (goog.i18n.DateTimeParse. pattern)
                                    date-string
                                    date)

--- a/test/axel_f/date_test.cljc
+++ b/test/axel_f/date_test.cljc
@@ -77,3 +77,7 @@
 (t/deftest format-test
   (t/is (= "1988-08-21" ((af/compile "coerce.to-string(DATE(1988, 8, 21))"))))
   (t/is (= "Aug-88-21" ((af/compile "coerce.to-string(DATE(1988, 8, 21), 'MMM-yy-dd')")))))
+
+(t/deftest parse-test
+  (t/is (= ["LocalDateTime" 1596193200000]
+           ((af/compile "PARSE.DATETIME('2020-07-31T11:00', \"yyyy-MM-dd'T'HH:mm\")")))))

--- a/test/axel_f/date_test.cljc
+++ b/test/axel_f/date_test.cljc
@@ -80,4 +80,4 @@
 
 (t/deftest parse-test
   (t/is (= ["LocalDateTime" 1596193200000]
-           ((af/compile "PARSE.DATETIME('2020-07-31T11:00:00.000', \"yyyy-MM-dd'T'HH:mm:ss.SSS\")")))))
+           ((af/compile "PARSE.DATETIME('2020-07-31T11:00', \"yyyy-MM-dd'T'HH:mm\")")))))

--- a/test/axel_f/date_test.cljc
+++ b/test/axel_f/date_test.cljc
@@ -80,4 +80,4 @@
 
 (t/deftest parse-test
   (t/is (= ["LocalDateTime" 1596193200000]
-           ((af/compile "PARSE.DATETIME('2020-07-31T11:00', \"yyyy-MM-dd'T'HH:mm\")")))))
+           ((af/compile "PARSE.DATETIME('2020-07-31T11:00:00.000', \"yyyy-MM-dd'T'HH:mm:ss.SSS\")")))))


### PR DESCRIPTION
Add two new function: `PARSE.DATE()` and `PARSE.DATETIME()`

The first argument is a date/time string, second - formatter string as described in section "Patterns for Formatting and Parsing" of [that article](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)

All alpha-characters in formatter string should be quoted using `'` character, eg. `"YYY'T'MM:ss"`